### PR TITLE
Update regex to work with github.cms.gov

### DIFF
--- a/metrics_dash_backend_tools/oss_metric_entities.py
+++ b/metrics_dash_backend_tools/oss_metric_entities.py
@@ -28,7 +28,11 @@ def get_repo_owner_and_name(repo_http_url):
     # The first group contains the owner of the github repo extracted from the url
     # The second group contains the name of the github repo extracted from the url
     # 'But what is a regular expression?' ----> https://docs.python.org/3/howto/regex.html
-    regex = r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
+    if 'cms.gov' in repo_http_url:
+        regex = r"https?:\/\/github\.cms\.gov\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
+    else:
+        regex = r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
+    
     result = re.search(regex, repo_http_url)
 
     if not result:

--- a/metrics_dash_backend_tools/oss_metric_entities.py
+++ b/metrics_dash_backend_tools/oss_metric_entities.py
@@ -8,6 +8,8 @@ import json
 import os
 import datetime
 import pathlib
+import urllib
+from urllib.parse import urlparse
 import requests
 from requests.exceptions import ReadTimeout
 from .constants import AUGUR_HOST
@@ -28,10 +30,13 @@ def get_repo_owner_and_name(repo_http_url):
     # The first group contains the owner of the github repo extracted from the url
     # The second group contains the name of the github repo extracted from the url
     # 'But what is a regular expression?' ----> https://docs.python.org/3/howto/regex.html
-    if 'cms.gov' in repo_http_url:
+    hostname = urlparse(repo_http_url).hostname
+    if 'cms.gov' in hostname:
         regex = r"https?:\/\/github\.cms\.gov\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
-    else:
+    elif hostname == "github.com":
         regex = r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
+    else:
+        return None, None
     
     result = re.search(regex, repo_http_url)
 

--- a/metrics_dash_backend_tools/oss_metric_entities.py
+++ b/metrics_dash_backend_tools/oss_metric_entities.py
@@ -31,7 +31,7 @@ def get_repo_owner_and_name(repo_http_url):
     # The second group contains the name of the github repo extracted from the url
     # 'But what is a regular expression?' ----> https://docs.python.org/3/howto/regex.html
     hostname = urlparse(repo_http_url).hostname
-    if 'cms.gov' in hostname:
+    if 'github.cms.gov' == hostname:
         regex = r"https?:\/\/github\.cms\.gov\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"
     elif hostname == "github.com":
         regex = r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metrics-dash-backend-tools"
-version = "0.1.1"
+version = "0.1.3"
 description = "Backend tools for the DSACMS OSPO metrics dashboard"
 authors = ["Isaac Milarsky <isaac.milarsky@hhs.cms.gov>"]
 license = "CC0"


### PR DESCRIPTION
## Update regex to work with github.cms.gov

## Problem

Right now the internal site won't work with the existing regex statement because it uses internal github.cms.gov

## Solution

Add an if statement to check for internal instance in url string 